### PR TITLE
ci(lint/release): don't make commitlint angry about long commit body lines

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,2 +1,4 @@
 extends:
   - "@commitlint/config-conventional"
+rules:
+  body-max-line-length: [2, "always", 256]


### PR DESCRIPTION
- this is so we can actually release despite dependabot being a jerk