### PR TITLE
DEVX-75: disable setup-go caching

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -119,6 +119,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.detect-go.outputs.VERSION }}
+        cache: false
 
     # since go versions are defined in different formats, it's better to let setup-go to handle it
     - name: Setup Go (from version file)
@@ -128,6 +129,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version-file: ${{ steps.detect-go.outputs.VERSION_FILE }}
+        cache: false
 
     # Detect version for Java from input or common version files.
     # This step enables conditional execution of the setup action,


### PR DESCRIPTION
**Description**
disable setup-go caching to avoid cache conflicts for now

![Screenshot 2025-05-21 at 12 55 01 PM](https://github.com/user-attachments/assets/076ed83a-fb8a-4e22-898b-eb404a6a9ede)


**Changes**

* fix(gha): disable cache for setup-go

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
